### PR TITLE
rewrite with go style

### DIFF
--- a/pocketflow_test.go
+++ b/pocketflow_test.go
@@ -1,7 +1,9 @@
 package pocketflow_test
 
 import (
+	"context"
 	"fmt"
+
 	// "strconv" // Removed unused import
 	"testing"
 	"time" // Added missing import
@@ -17,16 +19,16 @@ import (
 // setNumberNode creates a node that sets a number in the context.
 func setNumberNode(number int) pf.BaseNode {
 	n := pf.NewNode().
-		SetExec(func(prepResult any, params pf.SharedContext) (any, error) {
+		SetExec(func(ctx *pf.PfContext, params map[string]any, prepResult any) (any, error) {
 			multiplier := 1
 			if m, ok := params["multiplier"].(int); ok {
 				multiplier = m
 			}
 			return number * multiplier, nil // Exec result is the number
 		}).
-		SetPost(func(ctx pf.SharedContext, prepResult any, execResult any, params pf.SharedContext) (string, error) {
+		SetPost(func(ctx *pf.PfContext, params map[string]any, prepResult any, execResult any) (string, error) {
 			num := execResult.(int) // Assume execResult is int
-			ctx["currentValue"] = num
+			ctx.SetValue("currentValue", num)
 			if num > 20 {
 				return "over_20", nil
 			}
@@ -38,20 +40,22 @@ func setNumberNode(number int) pf.BaseNode {
 // addNumberNode creates a node that adds a number based on context.
 func addNumberNode(numberToAdd int) pf.BaseNode {
 	n := pf.NewNode().
-		SetPrep(func(ctx pf.SharedContext, params pf.SharedContext) (any, error) {
-			current, ok := ctx["currentValue"].(int)
+		SetPrep(func(ctx *pf.PfContext, params map[string]any) (any, error) {
+			// 原代码：current, ok := ctx["currentValue"].(int)
+			current, ok := ctx.Value("currentValue").(int)
 			if !ok {
 				return nil, fmt.Errorf("currentValue not found or not an int in context")
 			}
 			return current, nil // Prep result is the current value
 		}).
-		SetExec(func(prepResult any, params pf.SharedContext) (any, error) {
+		SetExec(func(ctx *pf.PfContext, params map[string]any, prepResult any) (any, error) {
 			current := prepResult.(int) // Assume prepResult is int
 			return current + numberToAdd, nil
 		}).
-		SetPost(func(ctx pf.SharedContext, prepResult any, execResult any, params pf.SharedContext) (string, error) {
+		SetPost(func(ctx *pf.PfContext, params map[string]any, prepResult any, execResult any) (string, error) {
 			num := execResult.(int) // Assume execResult is int
-			ctx["currentValue"] = num
+			// 原代码：ctx["currentValue"] = num
+			ctx.SetValue("currentValue", num)
 			return "added", nil // Action to trigger next node
 		})
 	return n
@@ -60,23 +64,24 @@ func addNumberNode(numberToAdd int) pf.BaseNode {
 // resultCaptureNode creates a node that captures the context value into its own params.
 func resultCaptureNode() pf.BaseNode {
 	n := pf.NewNode().
-		SetPrep(func(ctx pf.SharedContext, params pf.SharedContext) (any, error) {
-			val, ok := ctx["currentValue"]
-			if !ok {
+		SetPrep(func(ctx *pf.PfContext, params map[string]any) (any, error) {
+			// 原代码：val, ok := ctx["currentValue"]
+			val := ctx.Value("currentValue")
+			if val == nil {
 				// Provide a default if not found, mirroring Java test
 				return -999, nil
 			}
 			// Ensure the value is an int before returning
-            intVal, ok := val.(int)
-            if !ok {
-                return -999, fmt.Errorf("currentValue was not an int: %T", val)
-            }
+			intVal, ok := val.(int)
+			if !ok {
+				return -999, fmt.Errorf("currentValue was not an int: %T", val)
+			}
 			return intVal, nil
 		}).
-		SetExec(func(prepResult any, params pf.SharedContext) (any, error) {
+		SetExec(func(ctx *pf.PfContext, params map[string]any, prepResult any) (any, error) {
 			capturedVal := prepResult.(int)
 			params["capturedValue"] = capturedVal // Store in node's *own* params
-			return nil, nil                      // No meaningful exec result needed
+			return nil, nil                       // No meaningful exec result needed
 		})
 	// Default Post is sufficient (returns DefaultAction)
 	return n
@@ -85,15 +90,16 @@ func resultCaptureNode() pf.BaseNode {
 // simpleLogNode creates a node for BatchFlow testing.
 func simpleLogNode() pf.BaseNode {
 	n := pf.NewNode().
-		SetExec(func(prepResult any, params pf.SharedContext) (any, error) {
+		SetExec(func(ctx *pf.PfContext, params map[string]any, prepResult any) (any, error) {
 			multi := params["multiplier"] // Get multiplier from params set by BatchFlow
 			message := fmt.Sprintf("SimpleLogNode executed with multiplier: %v", multi)
 			return message, nil
 		}).
-		SetPost(func(ctx pf.SharedContext, prepResult any, execResult any, params pf.SharedContext) (string, error) {
+		SetPost(func(ctx *pf.PfContext, params map[string]any, prepResult any, execResult any) (string, error) {
 			message := execResult.(string)
 			key := fmt.Sprintf("last_message_from_batch_%v", params["multiplier"])
-			ctx[key] = message // Store message in shared context
+			// 原代码：ctx[key] = message
+			ctx.SetValue(key, message)
 			return pf.DefaultAction, nil
 		})
 	return n
@@ -110,14 +116,15 @@ func TestSimpleLinearFlow(t *testing.T) {
 	start.Next(pf.DefaultAction, add).Next("added", capture)
 
 	flow := pf.NewFlow(start)
-	sharedContext := make(pf.SharedContext)
+	sharedContext := pf.WithParam(context.Background(), nil)
 
 	lastAction, err := flow.Run(sharedContext)
 	require.NoError(t, err)
 
 	// Capture node is the last one, its default post returns "default"
 	assert.Equal(t, pf.DefaultAction, lastAction) // Flow's post returns last node's action
-	assert.Equal(t, 15, sharedContext["currentValue"])
+	// 原代码：assert.Equal(t, 15, sharedContext["currentValue"])
+	assert.Equal(t, 15, sharedContext.Value("currentValue"))
 
 	// Check the captured value in the capture node's *own* parameters
 	captureParams := capture.GetParams()
@@ -137,17 +144,18 @@ func TestBranchingFlow(t *testing.T) {
 	start.Next("over_20", captureOver20)
 
 	flow := pf.NewFlow(start)
-	sharedContext := make(pf.SharedContext)
+	sharedContext := pf.WithParam(context.Background(), nil)
 
 	// Set parameters on the flow, which will be passed to the start node
-	flow.SetParams(pf.SharedContext{"multiplier": 3})
+	flow.SetParams(map[string]any{"multiplier": 3})
 
 	lastAction, err := flow.Run(sharedContext)
 	require.NoError(t, err)
 
 	// The flow should take the "over_20" branch to captureOver20, which returns "default"
 	assert.Equal(t, pf.DefaultAction, lastAction)
-	assert.Equal(t, 30, sharedContext["currentValue"])
+	// 原代码：assert.Equal(t, 30, sharedContext["currentValue"])
+	assert.Equal(t, 30, sharedContext.Value("currentValue"))
 
 	// Check the correct capture node got the value
 	captureOver20Params := captureOver20.GetParams()
@@ -166,30 +174,31 @@ func TestBranchingFlow(t *testing.T) {
 func TestBatchFlowExecution(t *testing.T) {
 	batchFlow := pf.NewBatchFlow(simpleLogNode()) // Start node logs based on params
 
-	batchFlow.SetPrepBatch(func(ctx pf.SharedContext, params pf.SharedContext) ([]pf.SharedContext, error) {
+	batchFlow.SetPrepBatch(func(ctx *pf.PfContext, params map[string]any) ([]map[string]any, error) {
 		// Generate parameter sets for each batch run
-		return []pf.SharedContext{
+		return []map[string]any{
 			{"multiplier": 2},
 			{"multiplier": 4},
 		}, nil
 	})
 
-	batchFlow.SetPostBatch(func(ctx pf.SharedContext, batchPrepResult []pf.SharedContext, params pf.SharedContext) (string, error) {
-		ctx["postBatchCalled"] = true
+	batchFlow.SetPostBatch(func(ctx *pf.PfContext, params map[string]any, batchPrepResult []map[string]any) (string, error) {
+		// 原代码：ctx["postBatchCalled"] = true
+		ctx.SetValue("postBatchCalled", true)
 		assert.Len(t, batchPrepResult, 2, "PostBatch should receive the original prep result")
 		return "batch_complete", nil
 	})
 
-	batchContext := make(pf.SharedContext)
+	batchContext := pf.WithParam(context.Background(), nil)
 	resultAction, err := batchFlow.Run(batchContext)
 	require.NoError(t, err)
 
 	assert.Equal(t, "batch_complete", resultAction)
-	assert.True(t, batchContext["postBatchCalled"].(bool))
+	assert.True(t, batchContext.Value("postBatchCalled").(bool))
 
 	// Check that the log messages were stored in the shared context by the simpleLogNode's PostFunc
-	assert.Equal(t, "SimpleLogNode executed with multiplier: 2", batchContext["last_message_from_batch_2"])
-	assert.Equal(t, "SimpleLogNode executed with multiplier: 4", batchContext["last_message_from_batch_4"])
+	assert.Equal(t, "SimpleLogNode executed with multiplier: 2", batchContext.Value("last_message_from_batch_2"))
+	assert.Equal(t, "SimpleLogNode executed with multiplier: 4", batchContext.Value("last_message_from_batch_4"))
 }
 
 // --- Additional Tests ---
@@ -198,15 +207,16 @@ func TestNodeRetrySuccess(t *testing.T) {
 	execCount := 0
 	node := pf.NewNode().
 		SetRetry(3, 1*time.Millisecond). // Use time.Millisecond
-		SetExec(func(prepResult any, params pf.SharedContext) (any, error) {
+		SetExec(func(ctx *pf.PfContext, params map[string]any, prepResult any) (any, error) {
 			execCount++
 			if execCount < 3 {
 				return nil, fmt.Errorf("temporary failure %d", execCount)
 			}
 			return "success", nil // Succeeds on 3rd try
 		})
+	ctx := pf.WithParam(context.Background(), nil)
 
-	_, err := node.Run(make(pf.SharedContext))
+	_, err := node.Run(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, 3, execCount, "Exec should have been called 3 times")
 }
@@ -216,17 +226,18 @@ func TestNodeRetryFailureWithFallback(t *testing.T) {
 	fallbackCalled := false
 	node := pf.NewNode().
 		SetRetry(2, 1*time.Millisecond). // Use time.Millisecond
-		SetExec(func(prepResult any, params pf.SharedContext) (any, error) {
+		SetExec(func(ctx *pf.PfContext, params map[string]any, prepResult any) (any, error) {
 			execCount++
 			return nil, fmt.Errorf("permanent failure %d", execCount) // Always fail
 		}).
-		SetFallback(func(prepResult any, params pf.SharedContext, lastErr error) (any, error) {
+		SetFallback(func(ctx *pf.PfContext, params map[string]any, prepResult any, lastErr error) (any, error) {
 			fallbackCalled = true
 			assert.ErrorContains(t, lastErr, "permanent failure 2")
 			return "fallback_success", nil // Fallback succeeds
 		})
+	ctx := pf.WithParam(context.Background(), nil)
 
-	action, err := node.Run(make(pf.SharedContext))
+	action, err := node.Run(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, 2, execCount, "Exec should have been called 2 times")
 	assert.True(t, fallbackCalled, "Fallback should have been called")
@@ -237,13 +248,14 @@ func TestNodeRetryFailureWithoutFallback(t *testing.T) {
 	execCount := 0
 	node := pf.NewNode().
 		SetRetry(2, 1*time.Millisecond). // Use time.Millisecond
-		SetExec(func(prepResult any, params pf.SharedContext) (any, error) {
+		SetExec(func(ctx *pf.PfContext, params map[string]any, prepResult any) (any, error) {
 			execCount++
 			return nil, fmt.Errorf("permanent failure %d", execCount) // Always fail
 		})
 	// No fallback set
+	ctx := pf.WithParam(context.Background(), nil)
 
-	_, err := node.Run(make(pf.SharedContext))
+	_, err := node.Run(ctx)
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "Exec phase failed")
 	assert.ErrorContains(t, err, "permanent failure 2") // Check cause
@@ -256,10 +268,10 @@ func TestBatchNodeItemRetryAndFallback(t *testing.T) {
 
 	bnode := pf.NewBatchNode().
 		SetRetry(3, 1*time.Millisecond). // Use time.Millisecond - Retries per item
-		SetPrep(func(ctx pf.SharedContext, params pf.SharedContext) ([]any, error) {
+		SetPrep(func(ctx *pf.PfContext, params map[string]any) ([]any, error) {
 			return []any{"ok", "fail_once", "fail_always"}, nil
 		}).
-		SetExecItem(func(item any, params pf.SharedContext) (any, error) {
+		SetExecItem(func(ctx *pf.PfContext, params map[string]any, item any) (any, error) {
 			key := item.(string)
 			itemExecCounts[key]++
 			switch key {
@@ -275,7 +287,7 @@ func TestBatchNodeItemRetryAndFallback(t *testing.T) {
 			}
 			return nil, fmt.Errorf("unknown item")
 		}).
-		SetItemFallback(func(item any, params pf.SharedContext, lastErr error) (any, error) {
+		SetItemFallback(func(ctx *pf.PfContext, params map[string]any, item any, lastErr error) (any, error) {
 			key := item.(string)
 			if key == "fail_always" {
 				itemFallbackCalled[key] = true
@@ -285,13 +297,15 @@ func TestBatchNodeItemRetryAndFallback(t *testing.T) {
 			// Fallback should not be called for others
 			return nil, fmt.Errorf("unexpected fallback for %s", key)
 		}).
-		SetPost(func(ctx pf.SharedContext, prepResult []any, execResult []any, params pf.SharedContext) (string, error) {
+		SetPost(func(ctx *pf.PfContext, params map[string]any, prepResult []any, execResult []any) (string, error) {
 			// Store results in context for assertion
-			ctx["results"] = execResult
+			ctx.SetValue("results", execResult)
 			return "batch_done", nil
 		})
 
-	ctx := make(pf.SharedContext)
+	ctx := pf.WithParam(context.Background(), nil)
+	//ctx := context.Background()
+
 	action, err := bnode.Run(ctx)
 
 	require.NoError(t, err)
@@ -308,7 +322,7 @@ func TestBatchNodeItemRetryAndFallback(t *testing.T) {
 	assert.True(t, itemFallbackCalled["fail_always"])
 
 	// Check final results passed to Post
-	results := ctx["results"].([]any)
+	results := ctx.Value("results").([]any)
 	require.Len(t, results, 3)
 	assert.Equal(t, "OK_RES", results[0])
 	assert.Equal(t, "FAIL_ONCE_RES", results[1])


### PR DESCRIPTION
As a Go language backend developer, I recently used Go language to complete a React system. Based on my experience, I rewrote the key function in Pocketflow to make them more suitable for the practice of Go language. 

After this commit, I will continue to improve pocketflow-go and also release some of the practices I have written.

The convention in Go language is to always place `ctx` at the beginning. In this modification, the shared parameters at the request level are passed through the `ctx` parameter, while the shared parameters at the node level are passed through the `param` parameter of the node or flow itself.